### PR TITLE
Add missing __main__ entry point for train.py in Part 3

### DIFF
--- a/docs/03-training-loop.md
+++ b/docs/03-training-loop.md
@@ -173,6 +173,24 @@ def train(data_path, max_steps=5000, batch_size=64,
     return model, stoi, itos
 ```
 
+### Step 6: Entry Point
+
+Add this to the bottom of `train.py` so you can run it from the terminal:
+
+```python
+if __name__ == "__main__":
+    train("../data/shakespeare.txt")
+```
+
+This calls the training function with the default config (6L/6H/384D, 5000 steps) and the included Shakespeare dataset. You can customize the model by passing different arguments:
+
+```python
+if __name__ == "__main__":
+    import sys
+    data_path = sys.argv[1] if len(sys.argv) > 1 else "../data/shakespeare.txt"
+    train(data_path)
+```
+
 ### What Each Part Does
 
 **Validation loss**: Every 100 steps, evaluate on held-out data. If train loss goes down but val loss goes up, you're overfitting.


### PR DESCRIPTION
## Summary
- Add Step 6 showing the `if __name__ == "__main__"` block for `train.py`
- Include a variant with `sys.argv` for custom data paths

## Why
Part 5 instructs readers to run `python train.py`, but Part 3 only defines the `train()` function without ever calling it. Readers following the workshop would end up with a script that does nothing when run.

## Test plan
- [x] The code is syntactically valid Python
- [ ] `python train.py` runs training with default settings
- [ ] `python train.py /path/to/other/data.txt` uses the custom data path

🤖 Generated with [Claude Code](https://claude.com/claude-code)